### PR TITLE
Add GCC 13 compatibility: include cstdint for fixed-width integer types

### DIFF
--- a/qgenlib/dataframe.h
+++ b/qgenlib/dataframe.h
@@ -2,6 +2,7 @@
 #define __DATAFRAME_H
 
 #include <vector>
+#include <cstdint>
 #include <string>
 #include <map>
 

--- a/qgenlib/genome_interval.h
+++ b/qgenlib/genome_interval.h
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <cfloat>
 #include <vector>
+#include <cstdint>
 #include <map>
 #include "hts_utils.h"
 #include "qgen_utils.h"

--- a/qgenlib/genome_loci.h
+++ b/qgenlib/genome_loci.h
@@ -2,6 +2,7 @@
 #define __GENOME_LOCI_H
 
 #include <vector>
+#include <cstdint>
 #include <set>
 #include <map>
 #include <cstring>

--- a/qgenlib/gtf.h
+++ b/qgenlib/gtf.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <cstdint>
 #include <cstring>
 #include <climits>
 #include "qgen_error.h"

--- a/qgenlib/hts_utils.h
+++ b/qgenlib/hts_utils.h
@@ -26,11 +26,13 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
 #include <cfloat>
 #include <vector>
+#include <cstdint>
 #include <map>
 #include <queue>
 #include <sys/stat.h>

--- a/qgenlib/pos_loci.h
+++ b/qgenlib/pos_loci.h
@@ -4,6 +4,7 @@
 // this is very similar to genomeLocus, except that chrom is not a part of the key
 
 #include <vector>
+#include <cstdint>
 #include <set>
 #include <map>
 #include <cstring>

--- a/qgenlib/qgen_error.h
+++ b/qgenlib/qgen_error.h
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <stdexcept>
 #include <limits>
 

--- a/qgenlib/qgen_utils.h
+++ b/qgenlib/qgen_utils.h
@@ -31,12 +31,14 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <cstdlib>
 #include <climits>
 #include <cstring>
 #include <cmath>
 #include <cfloat>
 #include <vector>
+#include <cstdint>
 #include <map>
 #include <queue>
 

--- a/qgenlib/tsv_reader.h
+++ b/qgenlib/tsv_reader.h
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <climits>
 #include <vector>
+#include <cstdint>
 #include <map>
 #include <set>
 


### PR DESCRIPTION
## Summary

GCC 13 enforces stricter C++ standards where fixed-width integer types (`uint64_t`, `int64_t`, etc.) require explicit `#include <cstdint>`. This causes compilation failures on systems using GCC 13+, such as Ubuntu 24.04.

This PR adds `#include <cstdint>` to the following header files:
- `qgenlib/dataframe.h`
- `qgenlib/genome_interval.h`
- `qgenlib/genome_loci.h`
- `qgenlib/gtf.h`
- `qgenlib/hts_utils.h`
- `qgenlib/pos_loci.h`
- `qgenlib/qgen_error.h`
- `qgenlib/qgen_utils.h`
- `qgenlib/tsv_reader.h`

## Test Environment

- **OS**: Ubuntu 24.04 LTS
- **GCC**: 13.3.0
- **Tested with**: spatula build

## Error Examples (before fix)

```
error: 'uint64_t' was not declared in this scope
error: 'int64_t' was not declared in this scope
```

These errors occur because GCC 13 no longer implicitly includes `<cstdint>` through other standard headers.